### PR TITLE
mallocstack.rb to work

### DIFF
--- a/examples/mallocstack.rb
+++ b/examples/mallocstack.rb
@@ -58,7 +58,6 @@ stack_traces = b.get_table("stack_traces")
 calls.items.sort_by{|k, v| v.to_bcc_value }.reverse.each do |(k, v)|
   puts("%d bytes allocated at:" % v.to_bcc_value)
   stack_traces.walk(k) do |addr|
-    require 'pry'; binding.pry
     puts("\t%s" % BCC.sym(addr, pid, show_offset: true))
   end
 end

--- a/examples/mallocstack.rb
+++ b/examples/mallocstack.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+#
+# mallocstacks  Trace malloc() calls in a process and print the full
+#               stack trace for all callsites.
+#               For Linux, uses BCC, eBPF. Embedded C.
+#
+# This script is a basic example of the new Linux 4.6+ BPF_STACK_TRACE
+# table API.
+#
+# Copyright 2016 GitHub, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+require 'rbbcc'
+include RbBCC
+
+if ARGV.size == 0
+  $stderr.puts("USAGE: mallocstacks PID")
+  exit
+end
+pid = ARGV[0].to_i
+
+# load BPF program
+b = BCC.new(text: <<CLANG)
+#include <uapi/linux/ptrace.h>
+
+BPF_HASH(calls, int);
+BPF_STACK_TRACE(stack_traces, 1024);
+
+int alloc_enter(struct pt_regs *ctx, size_t size) {
+    int key = stack_traces.get_stackid(ctx,
+        BPF_F_USER_STACK|BPF_F_REUSE_STACKID);
+    if (key < 0)
+        return 0;
+
+    // could also use `calls.increment(key, size);`
+    u64 zero = 0, *val;
+    val = calls.lookup_or_init(&key, &zero);
+    if (val)
+      (*val) += size;
+    return 0;
+};
+CLANG
+
+b.attach_uprobe(name: "c", sym: "malloc", fn_name: "alloc_enter", pid: pid)
+puts("Attaching to malloc in pid %d, Ctrl+C to quit." % pid)
+
+# sleep until Ctrl-C
+loop do
+  begin
+    sleep 1
+  rescue Interrupt
+    break # pass
+  end
+end
+calls = b.get_table("calls")
+stack_traces = b.get_table("stack_traces")
+
+calls.items.sort_by{|k, v| v.to_bcc_value }.reverse.each do |(k, v)|
+  puts("%d bytes allocated at:" % v.to_bcc_value)
+  stack_traces.walk(k) do |addr|
+    require 'pry'; binding.pry
+    puts("\t%s" % BCC.sym(addr, pid, show_offset: true))
+  end
+end

--- a/lib/rbbcc/bcc.rb
+++ b/lib/rbbcc/bcc.rb
@@ -89,6 +89,64 @@ module RbBCC
         Clib.bcc_procutils_free(sym.module)
         return module_path, sym.offset
       end
+
+      def decode_table_type(desc)
+        return desc if desc.is_a?(String)
+
+        anon = []
+        fields = []
+        # e.g. ["bpf_stacktrace", [["ip", "unsigned long long", [127]]], "struct_packed"]
+        name, typedefs, data_type = desc
+        typedefs.each do |field|
+          case field.size
+          when 2
+            fields << "#{decode_table_type(field[1])} #{field[0]}"
+          when 3
+            ftype = field.last
+            if ftype.is_a?(Array)
+              fields << "#{decode_table_type(field[1])}[#{ftype[0]}] #{field[0]}"
+            elsif ftype.is_a?(Integer)
+              warn("Warning: Ruby fiddle does not support bitfield member, ignoring")
+              warn("Adding member `#{field[1]} #{field[0]}:#{ftype}'")
+              fields << "#{decode_table_type(field[1])} #{field[0]}"
+            elsif %w(union struct struct_packed).in?(ftype)
+              name = field[0]
+              if name.empty?
+                name = "__anon%d" % anon.size
+                anon << name
+              end
+              # FIXME: nested struct
+              fields << "#{decode_table_type(field)} #{name}"
+            else
+              raise("Failed to decode type #{field.inspect}")
+            end
+          else
+            raise("Failed to decode type #{field.inspect}")
+          end
+        end
+        if data_type == "union"
+          return Fiddle::Importer.union(fields)
+        else
+          return Fiddle::Importer.struct(fields)
+        end
+      end
+
+      def sym(addr, pid, show_module: false, show_offset: false, demangle: true)
+        # FIXME: case of typeofaddr.find('bpf_stack_build_id')
+        #s = Clib::BCCSymbol.malloc
+        #b = Clib::BCCStacktraceBuildID.malloc
+        #b.status = addr.status
+        #b.build_id = addr.build_id
+        #b.u = addr.offset
+        #Clib.bcc_buildsymcache_resolve(BPF.bsymcache, b, s)
+
+        name, offset_, module_ = SymbolCache.cache(pid).resolve(addr, demangle)
+        offset = (show_offset && name) ? ("+0x%x" % offset_) : ""
+        name = name || "[unknown]"
+        name = name + offset
+        module_ = (show_module && module_) ? " [#{File.basename.basename(module_)}]" : ""
+        return name + module_
+      end
     end
 
     def initialize(text:, debug: 0, cflags: [], usdt_contexts: [], allow_rlimit: 0)
@@ -178,7 +236,6 @@ module RbBCC
 
       fn = load_func(fn_name, BPF::KPROBE)
       ev_name = to_uprobe_evname("p", path, addr, pid)
-      # require 'pry'; binding.pry
       fd = Clib.bpf_attach_uprobe(fn[:fd], 0, ev_name, path, addr, pid)
       if fd < 0
         raise SystemCallError.new(Fiddle.last_error)
@@ -277,13 +334,14 @@ module RbBCC
       unless keytype
         key_desc = Clib.bpf_table_key_desc(@module, name)
         raise("Failed to load BPF Table #{name} key desc") if key_desc.null?
-        keytype = eval(key_desc.to_extracted_char_ptr) # XXX: parse as JSON?
+        keytype = BCC.decode_table_type(eval(key_desc.to_extracted_char_ptr))
       end
 
       unless leaftype
         leaf_desc = Clib.bpf_table_leaf_desc(@module, name)
         raise("Failed to load BPF Table #{name} leaf desc") if leaf_desc.null?
-        leaftype = eval(leaf_desc.to_extracted_char_ptr)
+
+        leaftype = BCC.decode_table_type(eval(leaf_desc.to_extracted_char_ptr))
       end
       return Table.new(self, map_id, map_fd, keytype, leaftype, name, reducer: reducer)
     end

--- a/lib/rbbcc/clib.rb
+++ b/lib/rbbcc/clib.rb
@@ -86,6 +86,13 @@ module RbBCC
                                'int check_debug_file_crc',
                                'unsigned int use_symbol_type'
                              ])
+    BCCIPOffsetUnion = union(['unsigned long long offset', 'unsigned long long ip'])
+    BCCStacktraceBuildID = \
+      struct([
+               'unsigned int status',
+               'unsigned char[20] build_id',
+               'unsigned long long u' # truly union
+             ])
     extern 'int bcc_resolve_symname(char *module, char *symname,
                         unsigned long long addr, int pid,
                         struct bcc_symbol_option* option,
@@ -95,6 +102,7 @@ module RbBCC
     extern 'int bcc_symcache_resolve(void *, unsigned long, void *)'
     extern 'int bcc_symcache_resolve_no_demangle(void *, unsigned long, void *)'
     extern 'int bcc_symcache_resolve_name(void *, char *, char *, unsigned long long *)'
+    extern 'void bcc_symbol_free_demangle_name(struct bcc_symbol *sym)'
 
     extern 'int perf_reader_poll(int num_readers, struct perf_reader **readers, int timeout)'
 

--- a/lib/rbbcc/clib.rb
+++ b/lib/rbbcc/clib.rb
@@ -81,7 +81,15 @@ module RbBCC
                          "const char *module",
                          "unsigned long offset"
                  ])
-
+    BCCSymbolOption = struct([
+                               'int use_debug_file',
+                               'int check_debug_file_crc',
+                               'unsigned int use_symbol_type'
+                             ])
+    extern 'int bcc_resolve_symname(char *module, char *symname,
+                        unsigned long long addr, int pid,
+                        struct bcc_symbol_option* option,
+                        struct bcc_symbol *sym)'
     extern 'void * bcc_symcache_new(int, void *)'
     extern 'void bcc_free_symcache(void *, int)'
     extern 'int bcc_symcache_resolve(void *, unsigned long, void *)'
@@ -89,6 +97,8 @@ module RbBCC
     extern 'int bcc_symcache_resolve_name(void *, char *, char *, unsigned long long *)'
 
     extern 'int perf_reader_poll(int num_readers, struct perf_reader **readers, int timeout)'
+
+    extern 'void bcc_procutils_free(const char *ptr)'
   end
 end
 

--- a/lib/rbbcc/symbol_cache.rb
+++ b/lib/rbbcc/symbol_cache.rb
@@ -24,21 +24,21 @@ module RbBCC
     end
 
     def resolve(addr, demangle)
-      sym = Clib::BCCSymcache.malloc
+      sym = Clib::BCCSymbol.malloc
       ret = if demangle
               Clib.bcc_symcache_resolve(@cache, addr, sym)
             else
               Clib.bcc_symcache_resolve_no_demangle(@cache, addr, sym)
             end
-      if res < 0
+      if ret < 0
         return [nil, addr, nil]
       end
 
       if demangle
-        name_res = sym.demangle_name
-        # Clib.bcc_symbol_free_demangle_name(sym)
+        name_res = Clib.__extract_char(sym.demangle_name)
+        Clib.bcc_symbol_free_demangle_name(sym)
       else
-        name_res = sym.name
+        name_res = Clib.__extract_char(sym.name)
       end
 
       return [name_res, sym.offset, Clib.__extract_char(sym.module)]


### PR DESCRIPTION
```console
# bundle exec ruby examples/mallocstack.rb -1
Found fnc: alloc_enter 
Attach: p__lib_x86_64_linux_gnu_libc_so_6_0x97070
Attaching to malloc in pid -1, Ctrl+C to quit.
^C66348 bytes allocated at:
        [unknown]      
15856 bytes allocated at:
        [unknown]     
        [unknown]       
        [unknown]      
14336 bytes allocated at:
        [unknown]     
        [unknown]       
        [unknown]      
11361 bytes allocated at:
        [unknown]      
        [unknown]       
        [unknown]     
11264 bytes allocated at:                                 
        [unknown]
        [unknown]
        [unknown]
3432 bytes allocated at:
        [unknown]
        [unknown]
        [unknown]

# bundle exec ruby examples/mallocstack.rb 22934
Found fnc: alloc_enter
Attach: p__lib_x86_64_linux_gnu_libc_2_27_so_0x97070_22934
Attaching to malloc in pid 22934, Ctrl+C to quit.
^C12288 bytes allocated at:
        __malloc+0x0
```