### PR TITLE
Support tracepoint

### DIFF
--- a/examples/urandomread-explicit.rb
+++ b/examples/urandomread-explicit.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+#
+# urandomread-explicit.rb Example of instrumenting a kernel tracepoint.
+#                         For Linux, uses BCC, BPF. Embedded C.
+# Originally urandomread-explicit.py in BCC
+#
+# This is an older example of instrumenting a tracepoint, which defines
+# the argument struct and makes an explicit call to attach_tracepoint().
+# See urandomread for a newer version that uses TRACEPOINT_PROBE().
+#
+# REQUIRES: Linux 4.7+ (BPF_PROG_TYPE_TRACEPOINT support).
+#
+# Test by running this, then in another shell, run:
+#     dd if=/dev/urandom of=/dev/null bs=1k count=5
+#
+# Copyright 2016 Netflix, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+require 'rbbcc'
+include RbBCC
+
+# define BPF program
+bpf_text = <<CLANG
+#include <uapi/linux/ptrace.h>
+
+struct urandom_read_args {
+    // from /sys/kernel/debug/tracing/events/random/urandom_read/format
+    u64 __unused__;
+    u32 got_bits;
+    u32 pool_left;
+    u32 input_left;
+};
+
+int printarg(struct urandom_read_args *args) {
+    bpf_trace_printk("%d\\n", args->got_bits);
+    return 0;
+}
+CLANG
+
+# load BPF program
+b = BCC.new(text: bpf_text)
+b.attach_tracepoint(tp: "random:urandom_read", fn_name: "printarg")
+
+# header
+printf("%-18s %-16s %-6s %s\n", "TIME(s)", "COMM", "PID", "GOTBITS")
+
+# format output
+loop do
+  begin
+    b.trace_fields do |task, pid, cpu, flags, ts, msg|
+      puts("%-18.9f %-16s %-6d %s" % [ts, task, pid, msg])
+    end
+  rescue Interrupt
+    exit
+  end
+end

--- a/lib/rbbcc/clib.rb
+++ b/lib/rbbcc/clib.rb
@@ -38,6 +38,8 @@ module RbBCC
     extern 'int bpf_detach_kprobe(char *)'
     extern 'int bpf_attach_uprobe(int, int, char *, char *, unsigned long, int)'
     extern 'int bpf_detach_uprobe(char *)'
+    extern 'int bpf_attach_tracepoint(int progfd, char *tp_category, char *tp_name)'
+    extern 'int bpf_detach_tracepoint(char *tp_category, char *tp_name)'
     extern 'int bpf_open_perf_event(unsigned int, unsigned long, int, int)'
     extern 'int bpf_close_perf_event_fd(int)'
     extern 'int bpf_get_first_key(int, void *, int)'


### PR DESCRIPTION
```console
$ ruby -rsecurerandom -e 'loop { p SecureRandom.rand; sleep 0.1 }'
```

```console
# bundle exec ruby examples/urandomread-explicit.rb                        
Found fnc: printarg
TIME(s)            COMM             PID    GOTBITS
15553.348673000    <...>            9724   128
15553.350468000    <...>            9724   128
15553.411191000    ruby             9724   8
15553.411274000    ruby             9724   64
15553.527484000    ruby             9724   64
15553.628097000    ruby             9724   64
15553.786098000    ruby             9724   64
15553.887759000    ruby             9724   64
15553.997933000    ruby             9724   64
15554.106885000    ruby             9724   64
15554.207439000    ruby             9724   64
15554.307781000    ruby             9724   64
15554.438771000    ruby             9724   64
15554.547744000    ruby             9724   64
15554.664829000    ruby             9724   64
15554.780588000    ruby             9724   64
15554.888065000    ruby             9724   64
15554.996591000    ruby             9724   64
15555.100410000    ruby             9724   64
15555.225458000    ruby             9724   64
```