### PR TITLE
Absorb the bcc_func_load args between 0.11/0.10

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@ RbBCC is a project to utilize the power of eBPF/BCC from Ruby.
 
 ## Setup
 
-RbBCC requires `libbcc.so` version **0.10.0**(we plan to support newer version of libbcc, but it may be done after rbbcc 1.0...).
+RbBCC requires `libbcc.so` version **0.11.0 or 0.10.0**(we plan to support newer version of libbcc, such as 0.12.0; but it may be done after rbbcc 1.0...).
 
 BTW we do not need to install header files, becuase current version of RbBCC uses the functionality of libbcc via ffi(We use MRI's standard library **fiddle**, not external gems).
 

--- a/examples/tools/execsnoop.rb
+++ b/examples/tools/execsnoop.rb
@@ -57,7 +57,7 @@ parser.on_tail("-h", "--help", "show this help message and exit") do
 end
 
 parser.parse!
-args.max_arges ||= "20"
+args.max_args ||= "20"
 
 bpf_text = <<CLANG
 #include <uapi/linux/ptrace.h>

--- a/lib/rbbcc/bcc.rb
+++ b/lib/rbbcc/bcc.rb
@@ -210,7 +210,7 @@ module RbBCC
       Clib.__extract_char ptr
     end
 
-    def load_func(func_name, prog_type)
+    def load_func(func_name, prog_type, device: nil)
       if @funcs.keys.include?(func_name)
         return @funcs[func_name]
       end
@@ -221,7 +221,7 @@ module RbBCC
              Clib.bpf_function_size(@module, func_name),
              Clib.bpf_module_license(@module),
              Clib.bpf_module_kern_version(@module),
-             log_level, nil, 0);
+             log_level, nil, 0, device);
       if fd < 0
         raise SystemCallError.new(Fiddle.last_error)
       end

--- a/lib/rbbcc/bcc.rb
+++ b/lib/rbbcc/bcc.rb
@@ -216,7 +216,7 @@ module RbBCC
       end
 
       log_level = 0
-      fd = Clib.bcc_func_load(@module, prog_type, func_name,
+      fd = Clib.do_bcc_func_load(@module, prog_type, func_name,
              Clib.bpf_function_start(@module, func_name),
              Clib.bpf_function_size(@module, func_name),
              Clib.bpf_module_license(@module),

--- a/lib/rbbcc/clib.rb
+++ b/lib/rbbcc/clib.rb
@@ -20,15 +20,18 @@ module RbBCC
       @@libbcc_version
     end
 
-    def self.libbcc_version?(ver)
-      @@libbcc_version == Gem::Version.new(ver)
+    def self.libbcc_version_gteq?(ver)
+      @@libbcc_version >= Gem::Version.new(ver)
     end
 
     extend Fiddle::Importer
     begin
-      dlload "libbcc.so.0.11.0"
-      self.libbcc_version = "0.11.0"
-    rescue Fiddle::DLError
+      default_load = ENV['LIBBCC_VERSION'] || "0.11.0"
+
+      dlload "libbcc.so.#{default_load}"
+      self.libbcc_version = default_load
+    rescue Fiddle::DLError => e
+      warn "Fall back to libbcc 0.10.0: #{e.inspect}"
       dlload "libbcc.so.0.10.0"
       self.libbcc_version = "0.10.0"
     end
@@ -39,7 +42,7 @@ module RbBCC
     extern 'char * bpf_function_name(void *, int)'
     extern 'void bpf_module_destroy(void *)'
 
-    if libbcc_version?("0.11.0")
+    if libbcc_version_gteq?("0.11.0")
       extern 'int bcc_func_load(
                   void *program, int prog_type, const char *name,
                   const struct bpf_insn *insns, int prog_len,


### PR DESCRIPTION
Now we're going to support 0.11.0!!!