### PR TITLE
Pass nil when cflags is empty

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,10 +10,12 @@ blocks:
       jobs:
         - name: ruby test
           matrix:
+            - env_var: RUBY_VERSION
+              values: [ "2.6.5", "2.6.6", "2.7.1" ]
             - env_var: LIBBCC_VERSION
               values: [ "0.12.0", "0.11.0", "0.10.0" ]
           commands:
             - sem-version c 7
-            - sem-version ruby 2.6.5
+            - sem-version ruby $RUBY_VERSION
             - checkout
             - ./semaphore.sh

--- a/lib/rbbcc/bcc.rb
+++ b/lib/rbbcc/bcc.rb
@@ -219,10 +219,16 @@ module RbBCC
         end
 
         # Util.debug text
+        cflags_p = if cflags.empty?
+                     nil
+                   else
+                     cflags.pack('p*')
+                   end
+
         @module = Clib.bpf_module_create_c_from_string(
           text,
           debug,
-          cflags.pack('p*'),
+          cflags_p,
           cflags.size,
           allow_rlimit
         )


### PR DESCRIPTION
Fix in Ruby 2.7 segv (tmp)