### PR TITLE
Fix definition of bpf_module_create_c_from_string

### DIFF
--- a/lib/rbbcc/bcc.rb
+++ b/lib/rbbcc/bcc.rb
@@ -221,7 +221,7 @@ module RbBCC
       end
     end
 
-    def initialize(text: "", src_file: nil, hdr_file: nil, debug: 0, cflags: [], usdt_contexts: [], allow_rlimit: 0)
+    def initialize(text: "", src_file: nil, hdr_file: nil, debug: 0, cflags: [], usdt_contexts: [], allow_rlimit: 0, dev_name: nil)
       @kprobe_fds = {}
       @uprobe_fds = {}
       @tracepoint_fds = {}
@@ -233,7 +233,7 @@ module RbBCC
       end
 
       if src_file && src_file.end_with?(".b")
-        @module = Clib.bpf_module_create_b(src_file, hdr_file, debug, device)
+        @module = Clib.bpf_module_create_b(src_file, hdr_file, debug, dev_name)
       else
         if src_file
           text = File.read(src_file)
@@ -251,12 +251,13 @@ module RbBCC
                         cflags
                       end
 
-        @module = Clib.bpf_module_create_c_from_string(
+        @module = Clib.do_bpf_module_create_c_from_string(
           text,
           debug,
           cflags_safe.pack("p*"),
           cflags_safe.size,
-          allow_rlimit
+          allow_rlimit,
+          dev_name
         )
       end
       @funcs = {}

--- a/lib/rbbcc/clib.rb
+++ b/lib/rbbcc/clib.rb
@@ -51,8 +51,8 @@ module RbBCC
 
     if libbcc_version_gteq?("0.11.0")
       extern 'void * bpf_module_create_c_from_string(
-                  const char *text, unsigned flags, const char *cflags[],
-                  int ncflags, bool allow_rlimit,
+                  const char *text, unsigned int flags, const char *cflags[],
+                  int ncflags, int allow_rlimit,
                   const char *dev_name)'
       extern 'int bcc_func_load(
                   void *program, int prog_type, const char *name,
@@ -69,8 +69,8 @@ module RbBCC
       end
     else
       extern 'void * bpf_module_create_c_from_string(
-                  const char *text, unsigned flags, const char *cflags[],
-                  int ncflags, bool allow_rlimit)'
+                  const char *text, unsigned int flags, const char *cflags[],
+                  int ncflags, int allow_rlimit)'
       extern 'int bcc_func_load(void *, int, char *, void *, int, char *, unsigned int, int, char *, unsigned int)'
       def self.do_bpf_module_create_c_from_string(text, flags, cflags, ncflags, allow_limit, dev_name=nil)
         bpf_module_create_c_from_string(text, flags, cflags, ncflags, allow_limit)

--- a/lib/rbbcc/clib.rb
+++ b/lib/rbbcc/clib.rb
@@ -44,24 +44,38 @@ module RbBCC
     end
     typealias "size_t", "int"
 
-    extern 'void * bpf_module_create_c_from_string(char *, unsigned int, char **, int, long)'
     extern 'void * bpf_module_create_b(char *filename, char *proto_filename, unsigned int flags, char *dev_name)'
     extern 'int bpf_num_functions(void *)'
     extern 'char * bpf_function_name(void *, int)'
     extern 'void bpf_module_destroy(void *)'
 
     if libbcc_version_gteq?("0.11.0")
+      extern 'void * bpf_module_create_c_from_string(
+                  const char *text, unsigned flags, const char *cflags[],
+                  int ncflags, bool allow_rlimit,
+                  const char *dev_name)'
       extern 'int bcc_func_load(
                   void *program, int prog_type, const char *name,
                   const struct bpf_insn *insns, int prog_len,
                   const char *license, unsigned int kern_version,
                   int log_level, char *log_buf, unsigned int log_buf_size,
                   const char *dev_name)'
+      def self.do_bpf_module_create_c_from_string(text, flags, cflags, ncflags, allow_limit, dev_name)
+        bpf_module_create_c_from_string(text, flags, cflags, ncflags, allow_limit, dev_name)
+      end
+
       def self.do_bcc_func_load(mod, prog_type, name, insns, len, license, kver, loglv, buf, buf_size, device)
         bcc_func_load(mod, prog_type, name, insns, len, license, kver, loglv, buf, buf_size, device)
       end
     else
+      extern 'void * bpf_module_create_c_from_string(
+                  const char *text, unsigned flags, const char *cflags[],
+                  int ncflags, bool allow_rlimit)'
       extern 'int bcc_func_load(void *, int, char *, void *, int, char *, unsigned int, int, char *, unsigned int)'
+      def self.do_bpf_module_create_c_from_string(text, flags, cflags, ncflags, allow_limit, dev_name=nil)
+        bpf_module_create_c_from_string(text, flags, cflags, ncflags, allow_limit)
+      end
+
       def self.do_bcc_func_load(mod, prog_type, name, insns, len, license, kver, loglv, buf, buf_size, device)
         bcc_func_load(mod, prog_type, name, insns, len, license, kver, loglv, buf, buf_size)
       end


### PR DESCRIPTION
After bcc 0.11.0, `bpf_module_create_c_from_string` is also has bee changed.